### PR TITLE
Add support for SWO features on RP2040

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,11 +33,11 @@ add_executable(akiprobe
   ${CMAKE_CURRENT_SOURCE_DIR}/src/main.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/usb_descriptors.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/cmsis_dap_device.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/cmsis-dap/SWO.c
 
   ${CMAKE_CURRENT_SOURCE_DIR}/lib/CMSIS-DAP/Firmware/Source/DAP.c
   ${CMAKE_CURRENT_SOURCE_DIR}/lib/CMSIS-DAP/Firmware/Source/JTAG_DP.c
   ${CMAKE_CURRENT_SOURCE_DIR}/lib/CMSIS-DAP/Firmware/Source/DAP_vendor.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/lib/CMSIS-DAP/Firmware/Source/SWO.c
   ${CMAKE_CURRENT_SOURCE_DIR}/lib/CMSIS-DAP/Firmware/Source/SW_DP.c
 )
 

--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,32 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+### Notice Regarding Third-Party Code
+
+This project includes code that is licensed under the Apache License 2.0.
+The following file is subject to the Apache License 2.0:
+
+- `src/cmsis-dap/SWO.c`
+
+For the file, the following license applies:
+
+------------------------------------------------------------------
+Apache License 2.0
+
+Copyright (c) 2013-2021 ARM Limited. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use these files except in compliance with the License.
+You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -70,14 +70,16 @@ $ cmake --build build_pico
 | SWCLK/TCK    |  4  | GP2    |
 | SWDIO/TMS    |  5  | GP3    |
 | TDI          |  1  | GP0    |
-| TDO          |  2  | GP1    |
+| TDO/SWO      |  2  | GP1    |
 | nRESET       |  9  | GP6    |
-| UART TX      | 11  | GP8    |
-| UART RX      | 12  | GP9    |
+| UART TX      |  6  | GP4    |
+| UART RX      |  7  | GP5    |
 
-# License
+# Licensing
 
-- Project's source code files are licensed under MIT license.
+- The majority of this project is licensed under the **MIT License**.
+- The following file is licensed under the **Apache License 2.0**:
+  - `src/cmsis-dap/SWO.c`
 - [TinyUSB](https://github.com/hathach/tinyusb) is licensed under the MIT license.
 - [CMSIS_6](https://github.com/ARM-software/CMSIS_6) is licensed under the Apache 2.0 license.
 - [CMSIS-DAP](https://github.com/ARM-software/CMSIS-DAP) is licensed under the Apache 2.0 license.

--- a/src/ae_lpc11u35_mb/board.c
+++ b/src/ae_lpc11u35_mb/board.c
@@ -175,6 +175,7 @@ void board_init(void)
 //--------------------------------------------------------------------+
 void board_led_write(bool state)
 {
+  (void)state;
 #ifdef LED_PORT
   Chip_GPIO_SetPinState(LPC_GPIO, LED_PORT, LED_PIN, state ? LED_STATE_ON : (1-LED_STATE_ON));
 #endif
@@ -185,21 +186,19 @@ uint32_t board_button_read(void)
   return BUTTON_STATE_ACTIVE == Chip_GPIO_GetPinState(LPC_GPIO, BUTTON_PORT, BUTTON_PIN);
 }
 
-void board_uart_set_baudrate(unsigned bit_rate)
+uint32_t board_uart_set_baudrate(unsigned bit_rate)
 {
-  Chip_UART_SetBaud(LPC_USART, bit_rate);
+  return Chip_UART_SetBaud(LPC_USART, bit_rate);
 }
 
 int board_uart_read(uint8_t* buf, int len)
 {
   return Chip_UART_Read(LPC_USART, buf, len);
-  //  return Chip_UART_ReadBlocking(LPC_USART, buf, len);
 }
 
 int board_uart_write(void const * buf, int len)
 {
   return Chip_UART_Send(LPC_USART, buf, len);
-  //  return Chip_UART_SendBlocking(LPC_USART, buf, len);
 }
 
 #if CFG_TUSB_OS == OPT_OS_NONE

--- a/src/board.h
+++ b/src/board.h
@@ -23,6 +23,7 @@
 #ifndef _BSP_BOARD_H_
 #define _BSP_BOARD_H_
 
+#include <stdbool.h>
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -32,14 +33,12 @@ extern "C" {
 #include "tusb.h"
 
 void board_init(void);
-
-void board_uart_set_baudrate(unsigned bit_rate);
-
-// Get characters from UART
+uint32_t board_uart_set_baudrate(unsigned bit_rate);
 int board_uart_read(uint8_t* buf, int len);
-
-// Send characters to UART
 int board_uart_write(void const * buf, int len);
+int board_swo_set_enabled(int enabled);
+uint32_t board_swo_set_baudrate(unsigned bit_rate);
+int board_swo_read(uint8_t* buf, int len);
 
 #ifdef __cplusplus
 }

--- a/src/cmsis-dap/SWO.c
+++ b/src/cmsis-dap/SWO.c
@@ -1,0 +1,798 @@
+/*
+ * Copyright (c) 2013-2021 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----------------------------------------------------------------------
+ *
+ * $Date:        29. March 2021
+ * $Revision:    V2.0.1
+ *
+ * Project:      CMSIS-DAP Source
+ * Title:        SWO.c CMSIS-DAP SWO I/O
+ *
+ *---------------------------------------------------------------------------*/
+
+#include "DAP_config.h"
+#include "DAP.h"
+#if (SWO_UART != 0)
+#include "Driver_USART.h"
+#endif
+#if (SWO_STREAM != 0)
+#include "cmsis_os2.h"
+#define   osObjectsExternal
+#include "osObjects.h"
+#endif
+
+#if (SWO_STREAM != 0)
+#ifdef DAP_FW_V1
+#error "SWO Streaming Trace not supported in DAP V1!"
+#endif
+#endif
+
+#if (SWO_UART != 0)
+
+// USART Driver
+#define _USART_Driver_(n)  Driver_USART##n
+#define  USART_Driver_(n) _USART_Driver_(n)
+extern ARM_DRIVER_USART    USART_Driver_(SWO_UART_DRIVER);
+#define pUSART           (&USART_Driver_(SWO_UART_DRIVER))
+
+static uint8_t USART_Ready = 0U;
+
+#endif  /* (SWO_UART != 0) */
+
+
+#if ((SWO_UART != 0) || (SWO_MANCHESTER != 0))
+
+
+#define SWO_STREAM_TIMEOUT      50U     /* Stream timeout in ms */
+
+#define USB_BLOCK_SIZE          512U    /* USB Block Size */
+#define TRACE_BLOCK_SIZE        64U     /* Trace Block Size (2^n: 32...512) */
+
+// Trace State
+static uint8_t  TraceTransport =  0U;       /* Trace Transport */
+static uint8_t  TraceMode      =  0U;       /* Trace Mode */
+static uint8_t  TraceStatus    =  0U;       /* Trace Status without Errors */
+static uint8_t  TraceError[2]  = {0U, 0U};  /* Trace Error flags (banked) */
+static uint8_t  TraceError_n   =  0U;       /* Active Trace Error bank */
+
+// Trace Buffer
+static uint8_t  TraceBuf[SWO_BUFFER_SIZE];  /* Trace Buffer (must be 2^n) */
+static volatile uint32_t TraceIndexI  = 0U; /* Incoming Trace Index */
+static volatile uint32_t TraceIndexO  = 0U; /* Outgoing Trace Index */
+static volatile uint8_t  TraceUpdate;       /* Trace Update Flag */
+static          uint32_t TraceBlockSize;    /* Current Trace Block Size */
+
+#if (TIMESTAMP_CLOCK != 0U)
+// Trace Timestamp
+static volatile struct {
+  uint32_t index;
+  uint32_t tick;
+} TraceTimestamp;
+#endif
+
+// Trace Helper functions
+static void     ClearTrace     (void);
+static void     ResumeTrace    (void);
+static uint32_t GetTraceCount  (void);
+static uint8_t  GetTraceStatus (void);
+static void     SetTraceError  (uint8_t flag);
+
+#if (SWO_STREAM != 0)
+extern osThreadId_t      SWO_ThreadId;
+static volatile uint8_t  TransferBusy = 0U; /* Transfer Busy Flag */
+static          uint32_t TransferSize;      /* Current Transfer Size */
+#endif
+
+
+#if (SWO_UART != 0)
+
+// USART Driver Callback function
+//   event: event mask
+static void USART_Callback (uint32_t event) {
+  uint32_t index_i;
+  uint32_t index_o;
+  uint32_t count;
+  uint32_t num;
+
+  if (event &  ARM_USART_EVENT_RECEIVE_COMPLETE) {
+#if (TIMESTAMP_CLOCK != 0U)
+    TraceTimestamp.tick = TIMESTAMP_GET();
+#endif
+    index_o  = TraceIndexO;
+    index_i  = TraceIndexI;
+    index_i += TraceBlockSize;
+    TraceIndexI = index_i;
+#if (TIMESTAMP_CLOCK != 0U)
+    TraceTimestamp.index = index_i;
+#endif
+    num   = TRACE_BLOCK_SIZE - (index_i & (TRACE_BLOCK_SIZE - 1U));
+    count = index_i - index_o;
+    if (count <= (SWO_BUFFER_SIZE - num)) {
+      index_i &= SWO_BUFFER_SIZE - 1U;
+      TraceBlockSize = num;
+      pUSART->Receive(&TraceBuf[index_i], num);
+    } else {
+      TraceStatus = DAP_SWO_CAPTURE_ACTIVE | DAP_SWO_CAPTURE_PAUSED;
+    }
+    TraceUpdate = 1U;
+#if (SWO_STREAM != 0)
+    if (TraceTransport == 2U) {
+      if (count >= (USB_BLOCK_SIZE - (index_o & (USB_BLOCK_SIZE - 1U)))) {
+        osThreadFlagsSet(SWO_ThreadId, 1U);
+      }
+    }
+#endif
+  }
+  if (event &  ARM_USART_EVENT_RX_OVERFLOW) {
+    SetTraceError(DAP_SWO_BUFFER_OVERRUN);
+  }
+  if (event & (ARM_USART_EVENT_RX_BREAK         |
+               ARM_USART_EVENT_RX_FRAMING_ERROR |
+               ARM_USART_EVENT_RX_PARITY_ERROR)) {
+    SetTraceError(DAP_SWO_STREAM_ERROR);
+  }
+}
+
+// Enable or disable SWO Mode (UART)
+//   enable: enable flag
+//   return: 1 - Success, 0 - Error
+__WEAK uint32_t SWO_Mode_UART (uint32_t enable) {
+  int32_t status;
+
+  USART_Ready = 0U;
+
+  if (enable != 0U) {
+    status = pUSART->Initialize(USART_Callback);
+    if (status != ARM_DRIVER_OK) {
+      return (0U);
+    }
+    status = pUSART->PowerControl(ARM_POWER_FULL);
+    if (status != ARM_DRIVER_OK) {
+      pUSART->Uninitialize();
+      return (0U);
+    }
+  } else {
+    pUSART->Control(ARM_USART_CONTROL_RX, 0U);
+    pUSART->Control(ARM_USART_ABORT_RECEIVE, 0U);
+    pUSART->PowerControl(ARM_POWER_OFF);
+    pUSART->Uninitialize();
+  }
+  return (1U);
+}
+
+// Configure SWO Baudrate (UART)
+//   baudrate: requested baudrate
+//   return:   actual baudrate or 0 when not configured
+__WEAK uint32_t SWO_Baudrate_UART (uint32_t baudrate) {
+  int32_t  status;
+  uint32_t index;
+  uint32_t num;
+
+  if (baudrate > SWO_UART_MAX_BAUDRATE) {
+    baudrate = SWO_UART_MAX_BAUDRATE;
+  }
+
+  if (TraceStatus & DAP_SWO_CAPTURE_ACTIVE) {
+    pUSART->Control(ARM_USART_CONTROL_RX, 0U);
+    if (pUSART->GetStatus().rx_busy) {
+      TraceIndexI += pUSART->GetRxCount();
+      pUSART->Control(ARM_USART_ABORT_RECEIVE, 0U);
+    }
+  }
+
+  status = pUSART->Control(ARM_USART_MODE_ASYNCHRONOUS |
+                           ARM_USART_DATA_BITS_8       |
+                           ARM_USART_PARITY_NONE       |
+                           ARM_USART_STOP_BITS_1,
+                           baudrate);
+
+  if (status == ARM_DRIVER_OK) {
+    USART_Ready = 1U;
+  } else {
+    USART_Ready = 0U;
+    return (0U);
+  }
+
+  if (TraceStatus & DAP_SWO_CAPTURE_ACTIVE) {
+    if ((TraceStatus & DAP_SWO_CAPTURE_PAUSED) == 0U) {
+      index = TraceIndexI & (SWO_BUFFER_SIZE - 1U);
+      num = TRACE_BLOCK_SIZE - (index & (TRACE_BLOCK_SIZE - 1U));
+      TraceBlockSize = num;
+      pUSART->Receive(&TraceBuf[index], num);
+    }
+    pUSART->Control(ARM_USART_CONTROL_RX, 1U);
+  }
+
+  return (baudrate);
+}
+
+// Control SWO Capture (UART)
+//   active: active flag
+//   return: 1 - Success, 0 - Error
+__WEAK uint32_t SWO_Control_UART (uint32_t active) {
+  int32_t status;
+
+  if (active) {
+    if (!USART_Ready) {
+      return (0U);
+    }
+    TraceBlockSize = 1U;
+    status = pUSART->Receive(&TraceBuf[0], 1U);
+    if (status != ARM_DRIVER_OK) {
+      return (0U);
+    }
+    status = pUSART->Control(ARM_USART_CONTROL_RX, 1U);
+    if (status != ARM_DRIVER_OK) {
+      return (0U);
+    }
+  } else {
+    pUSART->Control(ARM_USART_CONTROL_RX, 0U);
+    if (pUSART->GetStatus().rx_busy) {
+      TraceIndexI += pUSART->GetRxCount();
+      pUSART->Control(ARM_USART_ABORT_RECEIVE, 0U);
+    }
+  }
+  return (1U);
+}
+
+// Start SWO Capture (UART)
+//   buf: pointer to buffer for capturing
+//   num: number of bytes to capture
+__WEAK void SWO_Capture_UART (uint8_t *buf, uint32_t num) {
+  TraceBlockSize = num;
+  pUSART->Receive(buf, num);
+}
+
+// Get SWO Pending Trace Count (UART)
+//   return: number of pending trace data bytes
+__WEAK uint32_t SWO_GetCount_UART (void) {
+  uint32_t count;
+
+  if (pUSART->GetStatus().rx_busy) {
+    count = pUSART->GetRxCount();
+  } else {
+    count = 0U;
+  }
+  return (count);
+}
+
+#endif  /* (SWO_UART != 0) */
+
+
+#if (SWO_MANCHESTER != 0)
+
+// Enable or disable SWO Mode (Manchester)
+//   enable: enable flag
+//   return: 1 - Success, 0 - Error
+__WEAK uint32_t SWO_Mode_Manchester (uint32_t enable) {
+  return (0U);
+}
+
+// Configure SWO Baudrate (Manchester)
+//   baudrate: requested baudrate
+//   return:   actual baudrate or 0 when not configured
+__WEAK uint32_t SWO_Baudrate_Manchester (uint32_t baudrate) {
+  return (0U);
+}
+
+// Control SWO Capture (Manchester)
+//   active: active flag
+//   return: 1 - Success, 0 - Error
+__WEAK uint32_t SWO_Control_Manchester (uint32_t active) {
+  return (0U);
+}
+
+// Start SWO Capture (Manchester)
+//   buf: pointer to buffer for capturing
+//   num: number of bytes to capture
+__WEAK void SWO_Capture_Manchester (uint8_t *buf, uint32_t num) {
+}
+
+// Get SWO Pending Trace Count (Manchester)
+//   return: number of pending trace data bytes
+__WEAK uint32_t SWO_GetCount_Manchester (void) {
+}
+
+#endif  /* (SWO_MANCHESTER != 0) */
+
+
+// Clear Trace Errors and Data
+static void ClearTrace (void) {
+
+#if (SWO_STREAM != 0)
+  if (TraceTransport == 2U) {
+    if (TransferBusy != 0U) {
+      SWO_AbortTransfer();
+      TransferBusy = 0U;
+    }
+  }
+#endif
+
+  TraceError[0] = 0U;
+  TraceError[1] = 0U;
+  TraceError_n  = 0U;
+  TraceIndexI   = 0U;
+  TraceIndexO   = 0U;
+
+#if (TIMESTAMP_CLOCK != 0U)
+  TraceTimestamp.index = 0U;
+  TraceTimestamp.tick  = 0U;
+#endif
+}
+
+// Resume Trace Capture
+static void ResumeTrace (void) {
+  uint32_t index_i;
+  uint32_t index_o;
+
+  if (TraceStatus == (DAP_SWO_CAPTURE_ACTIVE | DAP_SWO_CAPTURE_PAUSED)) {
+    index_i = TraceIndexI;
+    index_o = TraceIndexO;
+    if ((index_i - index_o) < SWO_BUFFER_SIZE) {
+      index_i &= SWO_BUFFER_SIZE - 1U;
+      switch (TraceMode) {
+#if (SWO_UART != 0)
+        case DAP_SWO_UART:
+          TraceStatus = DAP_SWO_CAPTURE_ACTIVE;
+          SWO_Capture_UART(&TraceBuf[index_i], 1U);
+          break;
+#endif
+#if (SWO_MANCHESTER != 0)
+        case DAP_SWO_MANCHESTER:
+          TraceStatus = DAP_SWO_CAPTURE_ACTIVE;
+          SWO_Capture_Manchester(&TraceBuf[index_i], 1U);
+          break;
+#endif
+        default:
+          break;
+      }
+    }
+  }
+}
+
+// Get Trace Count
+//   return: number of available data bytes in trace buffer
+static uint32_t GetTraceCount (void) {
+  uint32_t count;
+
+  if (TraceStatus == DAP_SWO_CAPTURE_ACTIVE) {
+    do {
+      TraceUpdate = 0U;
+      count = TraceIndexI - TraceIndexO;
+      switch (TraceMode) {
+#if (SWO_UART != 0)
+        case DAP_SWO_UART:
+          count += SWO_GetCount_UART();
+          break;
+#endif
+#if (SWO_MANCHESTER != 0)
+        case DAP_SWO_MANCHESTER:
+          count += SWO_GetCount_Manchester();
+          break;
+#endif
+        default:
+          break;
+      }
+    } while (TraceUpdate != 0U);
+  } else {
+    count = TraceIndexI - TraceIndexO;
+  }
+
+  return (count);
+}
+
+// Get Trace Status (clear Error flags)
+//   return: Trace Status (Active flag and Error flags)
+static uint8_t GetTraceStatus (void) {
+  uint8_t  status;
+  uint32_t n;
+
+  n = TraceError_n;
+  TraceError_n ^= 1U;
+  status = TraceStatus | TraceError[n];
+  TraceError[n] = 0U;
+
+  return (status);
+}
+
+// Set Trace Error flag(s)
+//   flag:  error flag(s) to set
+static void SetTraceError (uint8_t flag) {
+  TraceError[TraceError_n] |= flag;
+}
+
+
+// Process SWO Transport command and prepare response
+//   request:  pointer to request data
+//   response: pointer to response data
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
+uint32_t SWO_Transport (const uint8_t *request, uint8_t *response) {
+  uint8_t  transport;
+  uint32_t result;
+
+  if ((TraceStatus & DAP_SWO_CAPTURE_ACTIVE) == 0U) {
+    transport = *request;
+    switch (transport) {
+      case 0U:
+      case 1U:
+#if (SWO_STREAM != 0)
+      case 2U:
+#endif
+        TraceTransport = transport;
+        result = 1U;
+        break;
+      default:
+        result = 0U;
+        break;
+    }
+  } else {
+    result = 0U;
+  }
+
+  if (result != 0U) {
+    *response = DAP_OK;
+  } else {
+    *response = DAP_ERROR;
+  }
+
+  return ((1U << 16) | 1U);
+}
+
+
+// Process SWO Mode command and prepare response
+//   request:  pointer to request data
+//   response: pointer to response data
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
+uint32_t SWO_Mode (const uint8_t *request, uint8_t *response) {
+  uint8_t  mode;
+  uint32_t result;
+
+  mode = *request;
+
+  switch (TraceMode) {
+#if (SWO_UART != 0)
+    case DAP_SWO_UART:
+      SWO_Mode_UART(0U);
+      break;
+#endif
+#if (SWO_MANCHESTER != 0)
+    case DAP_SWO_MANCHESTER:
+      SWO_Mode_Manchester(0U);
+      break;
+#endif
+    default:
+      break;
+  }
+
+  switch (mode) {
+    case DAP_SWO_OFF:
+      result = 1U;
+      break;
+#if (SWO_UART != 0)
+    case DAP_SWO_UART:
+      result = SWO_Mode_UART(1U);
+      break;
+#endif
+#if (SWO_MANCHESTER != 0)
+    case DAP_SWO_MANCHESTER:
+      result = SWO_Mode_Manchester(1U);
+      break;
+#endif
+    default:
+      result = 0U;
+      break;
+  }
+  if (result != 0U) {
+    TraceMode = mode;
+  } else {
+    TraceMode = DAP_SWO_OFF;
+  }
+
+  TraceStatus = 0U;
+
+  if (result != 0U) {
+    *response = DAP_OK;
+  } else {
+    *response = DAP_ERROR;
+  }
+
+  return ((1U << 16) | 1U);
+}
+
+
+// Process SWO Baudrate command and prepare response
+//   request:  pointer to request data
+//   response: pointer to response data
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
+uint32_t SWO_Baudrate (const uint8_t *request, uint8_t *response) {
+  uint32_t baudrate;
+
+  baudrate = (uint32_t)(*(request+0) <<  0) |
+             (uint32_t)(*(request+1) <<  8) |
+             (uint32_t)(*(request+2) << 16) |
+             (uint32_t)(*(request+3) << 24);
+
+  switch (TraceMode) {
+#if (SWO_UART != 0)
+    case DAP_SWO_UART:
+      baudrate = SWO_Baudrate_UART(baudrate);
+      break;
+#endif
+#if (SWO_MANCHESTER != 0)
+    case DAP_SWO_MANCHESTER:
+      baudrate = SWO_Baudrate_Manchester(baudrate);
+      break;
+#endif
+    default:
+      baudrate = 0U;
+      break;
+  }
+
+  if (baudrate == 0U) {
+    TraceStatus = 0U;
+  }
+
+  *response++ = (uint8_t)(baudrate >>  0);
+  *response++ = (uint8_t)(baudrate >>  8);
+  *response++ = (uint8_t)(baudrate >> 16);
+  *response   = (uint8_t)(baudrate >> 24);
+
+  return ((4U << 16) | 4U);
+}
+
+
+// Process SWO Control command and prepare response
+//   request:  pointer to request data
+//   response: pointer to response data
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
+uint32_t SWO_Control (const uint8_t *request, uint8_t *response) {
+  uint8_t  active;
+  uint32_t result;
+
+  active = *request & DAP_SWO_CAPTURE_ACTIVE;
+
+  if (active != (TraceStatus & DAP_SWO_CAPTURE_ACTIVE)) {
+    if (active) {
+      ClearTrace();
+    }
+    switch (TraceMode) {
+#if (SWO_UART != 0)
+      case DAP_SWO_UART:
+        result = SWO_Control_UART(active);
+        break;
+#endif
+#if (SWO_MANCHESTER != 0)
+      case DAP_SWO_MANCHESTER:
+        result = SWO_Control_Manchester(active);
+        break;
+#endif
+      default:
+        result = 0U;
+        break;
+    }
+    if (result != 0U) {
+      TraceStatus = active;
+#if (SWO_STREAM != 0)
+      if (TraceTransport == 2U) {
+        osThreadFlagsSet(SWO_ThreadId, 1U);
+      }
+#endif
+    }
+  } else {
+    result = 1U;
+  }
+
+  if (result != 0U) {
+    *response = DAP_OK;
+  } else {
+    *response = DAP_ERROR;
+  }
+
+  return ((1U << 16) | 1U);
+}
+
+
+// Process SWO Status command and prepare response
+//   response: pointer to response data
+//   return:   number of bytes in response
+uint32_t SWO_Status (uint8_t *response) {
+  uint8_t  status;
+  uint32_t count;
+
+  status = GetTraceStatus();
+  count  = GetTraceCount();
+
+  *response++ = status;
+  *response++ = (uint8_t)(count >>  0);
+  *response++ = (uint8_t)(count >>  8);
+  *response++ = (uint8_t)(count >> 16);
+  *response   = (uint8_t)(count >> 24);
+
+  return (5U);
+}
+
+
+// Process SWO Extended Status command and prepare response
+//   request:  pointer to request data
+//   response: pointer to response data
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
+uint32_t SWO_ExtendedStatus (const uint8_t *request, uint8_t *response) {
+  uint8_t  cmd;
+  uint8_t  status;
+  uint32_t count;
+#if (TIMESTAMP_CLOCK != 0U)
+  uint32_t index;
+  uint32_t tick;
+#endif
+  uint32_t num;
+
+  num = 0U;
+  cmd = *request;
+
+  if (cmd & 0x01U) {
+    status = GetTraceStatus();
+    *response++ = status;
+    num += 1U;
+  }
+
+  if (cmd & 0x02U) {
+    count = GetTraceCount();
+    *response++ = (uint8_t)(count >>  0);
+    *response++ = (uint8_t)(count >>  8);
+    *response++ = (uint8_t)(count >> 16);
+    *response++ = (uint8_t)(count >> 24);
+    num += 4U;
+  }
+
+#if (TIMESTAMP_CLOCK != 0U)
+  if (cmd & 0x04U) {
+    do {
+      TraceUpdate = 0U;
+      index = TraceTimestamp.index;
+      tick  = TraceTimestamp.tick;
+    } while (TraceUpdate != 0U);
+    *response++ = (uint8_t)(index >>  0);
+    *response++ = (uint8_t)(index >>  8);
+    *response++ = (uint8_t)(index >> 16);
+    *response++ = (uint8_t)(index >> 24);
+    *response++ = (uint8_t)(tick  >>  0);
+    *response++ = (uint8_t)(tick  >>  8);
+    *response++ = (uint8_t)(tick  >> 16);
+    *response++ = (uint8_t)(tick  >> 24);
+    num += 4U;
+  }
+#endif
+
+  return ((1U << 16) | num);
+}
+
+
+// Process SWO Data command and prepare response
+//   request:  pointer to request data
+//   response: pointer to response data
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
+uint32_t SWO_Data (const uint8_t *request, uint8_t *response) {
+  uint8_t  status;
+  uint32_t count;
+  uint32_t index;
+  uint32_t n, i;
+
+  status = GetTraceStatus();
+  count  = GetTraceCount();
+
+  if (TraceTransport == 1U) {
+    n = (uint32_t)(*(request+0) << 0) |
+        (uint32_t)(*(request+1) << 8);
+    if (n > (DAP_PACKET_SIZE - 4U)) {
+      n = DAP_PACKET_SIZE - 4U;
+    }
+    if (count > n) {
+      count = n;
+    }
+  } else {
+    count = 0U;
+  }
+
+  *response++ = status;
+  *response++ = (uint8_t)(count >> 0);
+  *response++ = (uint8_t)(count >> 8);
+
+  if (TraceTransport == 1U) {
+    index = TraceIndexO;
+    for (i = index, n = count; n; n--) {
+      i &= SWO_BUFFER_SIZE - 1U;
+      *response++ = TraceBuf[i++];
+    }
+    TraceIndexO = index + count;
+    ResumeTrace();
+  }
+
+  return ((2U << 16) | (3U + count));
+}
+
+
+#if (SWO_STREAM != 0)
+
+// SWO Data Transfer complete callback
+void SWO_TransferComplete (void) {
+  TraceIndexO += TransferSize;
+  TransferBusy = 0U;
+  ResumeTrace();
+  osThreadFlagsSet(SWO_ThreadId, 1U);
+}
+
+// SWO Thread
+__NO_RETURN void SWO_Thread (void *argument) {
+  uint32_t timeout;
+  uint32_t flags;
+  uint32_t count;
+  uint32_t index;
+  uint32_t i, n;
+  (void)   argument;
+
+  timeout = osWaitForever;
+
+  for (;;) {
+    flags = osThreadFlagsWait(1U, osFlagsWaitAny, timeout);
+    if (TraceStatus & DAP_SWO_CAPTURE_ACTIVE) {
+      timeout = SWO_STREAM_TIMEOUT;
+    } else {
+      timeout = osWaitForever;
+      flags   = osFlagsErrorTimeout;
+    }
+    if (TransferBusy == 0U) {
+      count = GetTraceCount();
+      if (count != 0U) {
+        index = TraceIndexO & (SWO_BUFFER_SIZE - 1U);
+        n = SWO_BUFFER_SIZE - index;
+        if (count > n) {
+          count = n;
+        }
+        if (flags != osFlagsErrorTimeout) {
+          i = index & (USB_BLOCK_SIZE - 1U);
+          if (i == 0U) {
+            count &= ~(USB_BLOCK_SIZE - 1U);
+          } else {
+            n = USB_BLOCK_SIZE - i;
+            if (count >= n) {
+              count = n;
+            } else {
+              count = 0U;
+            }
+          }
+        }
+        if (count != 0U) {
+          TransferSize = count;
+          TransferBusy = 1U;
+          SWO_QueueTransfer(&TraceBuf[index], count);
+        }
+      }
+    }
+  }
+}
+
+#endif  /* (SWO_STREAM != 0) */
+
+
+#endif  /* ((SWO_UART != 0) || (SWO_MANCHESTER != 0)) */

--- a/src/cmsis-dap/SWO.c
+++ b/src/cmsis-dap/SWO.c
@@ -27,14 +27,7 @@
 
 #include "DAP_config.h"
 #include "DAP.h"
-#if (SWO_UART != 0)
-#include "Driver_USART.h"
-#endif
-#if (SWO_STREAM != 0)
-#include "cmsis_os2.h"
-#define   osObjectsExternal
-#include "osObjects.h"
-#endif
+#include <stdint.h>
 
 #if (SWO_STREAM != 0)
 #ifdef DAP_FW_V1
@@ -42,26 +35,12 @@
 #endif
 #endif
 
-#if (SWO_UART != 0)
-
-// USART Driver
-#define _USART_Driver_(n)  Driver_USART##n
-#define  USART_Driver_(n) _USART_Driver_(n)
-extern ARM_DRIVER_USART    USART_Driver_(SWO_UART_DRIVER);
-#define pUSART           (&USART_Driver_(SWO_UART_DRIVER))
-
-static uint8_t USART_Ready = 0U;
-
-#endif  /* (SWO_UART != 0) */
-
-
 #if ((SWO_UART != 0) || (SWO_MANCHESTER != 0))
 
 
 #define SWO_STREAM_TIMEOUT      50U     /* Stream timeout in ms */
 
 #define USB_BLOCK_SIZE          512U    /* USB Block Size */
-#define TRACE_BLOCK_SIZE        64U     /* Trace Block Size (2^n: 32...512) */
 
 // Trace State
 static uint8_t  TraceTransport =  0U;       /* Trace Transport */
@@ -69,13 +48,6 @@ static uint8_t  TraceMode      =  0U;       /* Trace Mode */
 static uint8_t  TraceStatus    =  0U;       /* Trace Status without Errors */
 static uint8_t  TraceError[2]  = {0U, 0U};  /* Trace Error flags (banked) */
 static uint8_t  TraceError_n   =  0U;       /* Active Trace Error bank */
-
-// Trace Buffer
-static uint8_t  TraceBuf[SWO_BUFFER_SIZE];  /* Trace Buffer (must be 2^n) */
-static volatile uint32_t TraceIndexI  = 0U; /* Incoming Trace Index */
-static volatile uint32_t TraceIndexO  = 0U; /* Outgoing Trace Index */
-static volatile uint8_t  TraceUpdate;       /* Trace Update Flag */
-static          uint32_t TraceBlockSize;    /* Current Trace Block Size */
 
 #if (TIMESTAMP_CLOCK != 0U)
 // Trace Timestamp
@@ -87,192 +59,16 @@ static volatile struct {
 
 // Trace Helper functions
 static void     ClearTrace     (void);
-static void     ResumeTrace    (void);
 static uint32_t GetTraceCount  (void);
-static uint8_t  GetTraceStatus (void);
+uint8_t  GetTraceStatus (void);
+#if 0
 static void     SetTraceError  (uint8_t flag);
-
-#if (SWO_STREAM != 0)
-extern osThreadId_t      SWO_ThreadId;
-static volatile uint8_t  TransferBusy = 0U; /* Transfer Busy Flag */
-static          uint32_t TransferSize;      /* Current Transfer Size */
 #endif
-
-
-#if (SWO_UART != 0)
-
-// USART Driver Callback function
-//   event: event mask
-static void USART_Callback (uint32_t event) {
-  uint32_t index_i;
-  uint32_t index_o;
-  uint32_t count;
-  uint32_t num;
-
-  if (event &  ARM_USART_EVENT_RECEIVE_COMPLETE) {
-#if (TIMESTAMP_CLOCK != 0U)
-    TraceTimestamp.tick = TIMESTAMP_GET();
-#endif
-    index_o  = TraceIndexO;
-    index_i  = TraceIndexI;
-    index_i += TraceBlockSize;
-    TraceIndexI = index_i;
-#if (TIMESTAMP_CLOCK != 0U)
-    TraceTimestamp.index = index_i;
-#endif
-    num   = TRACE_BLOCK_SIZE - (index_i & (TRACE_BLOCK_SIZE - 1U));
-    count = index_i - index_o;
-    if (count <= (SWO_BUFFER_SIZE - num)) {
-      index_i &= SWO_BUFFER_SIZE - 1U;
-      TraceBlockSize = num;
-      pUSART->Receive(&TraceBuf[index_i], num);
-    } else {
-      TraceStatus = DAP_SWO_CAPTURE_ACTIVE | DAP_SWO_CAPTURE_PAUSED;
-    }
-    TraceUpdate = 1U;
-#if (SWO_STREAM != 0)
-    if (TraceTransport == 2U) {
-      if (count >= (USB_BLOCK_SIZE - (index_o & (USB_BLOCK_SIZE - 1U)))) {
-        osThreadFlagsSet(SWO_ThreadId, 1U);
-      }
-    }
-#endif
-  }
-  if (event &  ARM_USART_EVENT_RX_OVERFLOW) {
-    SetTraceError(DAP_SWO_BUFFER_OVERRUN);
-  }
-  if (event & (ARM_USART_EVENT_RX_BREAK         |
-               ARM_USART_EVENT_RX_FRAMING_ERROR |
-               ARM_USART_EVENT_RX_PARITY_ERROR)) {
-    SetTraceError(DAP_SWO_STREAM_ERROR);
-  }
-}
-
-// Enable or disable SWO Mode (UART)
-//   enable: enable flag
-//   return: 1 - Success, 0 - Error
-__WEAK uint32_t SWO_Mode_UART (uint32_t enable) {
-  int32_t status;
-
-  USART_Ready = 0U;
-
-  if (enable != 0U) {
-    status = pUSART->Initialize(USART_Callback);
-    if (status != ARM_DRIVER_OK) {
-      return (0U);
-    }
-    status = pUSART->PowerControl(ARM_POWER_FULL);
-    if (status != ARM_DRIVER_OK) {
-      pUSART->Uninitialize();
-      return (0U);
-    }
-  } else {
-    pUSART->Control(ARM_USART_CONTROL_RX, 0U);
-    pUSART->Control(ARM_USART_ABORT_RECEIVE, 0U);
-    pUSART->PowerControl(ARM_POWER_OFF);
-    pUSART->Uninitialize();
-  }
-  return (1U);
-}
-
-// Configure SWO Baudrate (UART)
-//   baudrate: requested baudrate
-//   return:   actual baudrate or 0 when not configured
-__WEAK uint32_t SWO_Baudrate_UART (uint32_t baudrate) {
-  int32_t  status;
-  uint32_t index;
-  uint32_t num;
-
-  if (baudrate > SWO_UART_MAX_BAUDRATE) {
-    baudrate = SWO_UART_MAX_BAUDRATE;
-  }
-
-  if (TraceStatus & DAP_SWO_CAPTURE_ACTIVE) {
-    pUSART->Control(ARM_USART_CONTROL_RX, 0U);
-    if (pUSART->GetStatus().rx_busy) {
-      TraceIndexI += pUSART->GetRxCount();
-      pUSART->Control(ARM_USART_ABORT_RECEIVE, 0U);
-    }
-  }
-
-  status = pUSART->Control(ARM_USART_MODE_ASYNCHRONOUS |
-                           ARM_USART_DATA_BITS_8       |
-                           ARM_USART_PARITY_NONE       |
-                           ARM_USART_STOP_BITS_1,
-                           baudrate);
-
-  if (status == ARM_DRIVER_OK) {
-    USART_Ready = 1U;
-  } else {
-    USART_Ready = 0U;
-    return (0U);
-  }
-
-  if (TraceStatus & DAP_SWO_CAPTURE_ACTIVE) {
-    if ((TraceStatus & DAP_SWO_CAPTURE_PAUSED) == 0U) {
-      index = TraceIndexI & (SWO_BUFFER_SIZE - 1U);
-      num = TRACE_BLOCK_SIZE - (index & (TRACE_BLOCK_SIZE - 1U));
-      TraceBlockSize = num;
-      pUSART->Receive(&TraceBuf[index], num);
-    }
-    pUSART->Control(ARM_USART_CONTROL_RX, 1U);
-  }
-
-  return (baudrate);
-}
-
-// Control SWO Capture (UART)
-//   active: active flag
-//   return: 1 - Success, 0 - Error
-__WEAK uint32_t SWO_Control_UART (uint32_t active) {
-  int32_t status;
-
-  if (active) {
-    if (!USART_Ready) {
-      return (0U);
-    }
-    TraceBlockSize = 1U;
-    status = pUSART->Receive(&TraceBuf[0], 1U);
-    if (status != ARM_DRIVER_OK) {
-      return (0U);
-    }
-    status = pUSART->Control(ARM_USART_CONTROL_RX, 1U);
-    if (status != ARM_DRIVER_OK) {
-      return (0U);
-    }
-  } else {
-    pUSART->Control(ARM_USART_CONTROL_RX, 0U);
-    if (pUSART->GetStatus().rx_busy) {
-      TraceIndexI += pUSART->GetRxCount();
-      pUSART->Control(ARM_USART_ABORT_RECEIVE, 0U);
-    }
-  }
-  return (1U);
-}
-
-// Start SWO Capture (UART)
-//   buf: pointer to buffer for capturing
-//   num: number of bytes to capture
-__WEAK void SWO_Capture_UART (uint8_t *buf, uint32_t num) {
-  TraceBlockSize = num;
-  pUSART->Receive(buf, num);
-}
-
-// Get SWO Pending Trace Count (UART)
-//   return: number of pending trace data bytes
-__WEAK uint32_t SWO_GetCount_UART (void) {
-  uint32_t count;
-
-  if (pUSART->GetStatus().rx_busy) {
-    count = pUSART->GetRxCount();
-  } else {
-    count = 0U;
-  }
-  return (count);
-}
-
-#endif  /* (SWO_UART != 0) */
-
+// Trace Buffer functions
+uint32_t TraceBuffer_IsUpdated(void);
+uint32_t TraceBuffer_GetCount(void);
+void     TraceBuffer_Clear (void);
+void     TraceBuffer_Drain (uint8_t *data, uint32_t num);
 
 #if (SWO_MANCHESTER != 0)
 
@@ -312,22 +108,12 @@ __WEAK uint32_t SWO_GetCount_Manchester (void) {
 
 
 // Clear Trace Errors and Data
-static void ClearTrace (void) {
-
-#if (SWO_STREAM != 0)
-  if (TraceTransport == 2U) {
-    if (TransferBusy != 0U) {
-      SWO_AbortTransfer();
-      TransferBusy = 0U;
-    }
-  }
-#endif
-
+static void ClearTrace (void)
+{
   TraceError[0] = 0U;
   TraceError[1] = 0U;
   TraceError_n  = 0U;
-  TraceIndexI   = 0U;
-  TraceIndexO   = 0U;
+  TraceBuffer_Clear();
 
 #if (TIMESTAMP_CLOCK != 0U)
   TraceTimestamp.index = 0U;
@@ -335,70 +121,17 @@ static void ClearTrace (void) {
 #endif
 }
 
-// Resume Trace Capture
-static void ResumeTrace (void) {
-  uint32_t index_i;
-  uint32_t index_o;
-
-  if (TraceStatus == (DAP_SWO_CAPTURE_ACTIVE | DAP_SWO_CAPTURE_PAUSED)) {
-    index_i = TraceIndexI;
-    index_o = TraceIndexO;
-    if ((index_i - index_o) < SWO_BUFFER_SIZE) {
-      index_i &= SWO_BUFFER_SIZE - 1U;
-      switch (TraceMode) {
-#if (SWO_UART != 0)
-        case DAP_SWO_UART:
-          TraceStatus = DAP_SWO_CAPTURE_ACTIVE;
-          SWO_Capture_UART(&TraceBuf[index_i], 1U);
-          break;
-#endif
-#if (SWO_MANCHESTER != 0)
-        case DAP_SWO_MANCHESTER:
-          TraceStatus = DAP_SWO_CAPTURE_ACTIVE;
-          SWO_Capture_Manchester(&TraceBuf[index_i], 1U);
-          break;
-#endif
-        default:
-          break;
-      }
-    }
-  }
-}
-
 // Get Trace Count
 //   return: number of available data bytes in trace buffer
-static uint32_t GetTraceCount (void) {
-  uint32_t count;
-
-  if (TraceStatus == DAP_SWO_CAPTURE_ACTIVE) {
-    do {
-      TraceUpdate = 0U;
-      count = TraceIndexI - TraceIndexO;
-      switch (TraceMode) {
-#if (SWO_UART != 0)
-        case DAP_SWO_UART:
-          count += SWO_GetCount_UART();
-          break;
-#endif
-#if (SWO_MANCHESTER != 0)
-        case DAP_SWO_MANCHESTER:
-          count += SWO_GetCount_Manchester();
-          break;
-#endif
-        default:
-          break;
-      }
-    } while (TraceUpdate != 0U);
-  } else {
-    count = TraceIndexI - TraceIndexO;
-  }
-
-  return (count);
+uint32_t GetTraceCount (void)
+{
+  return TraceBuffer_GetCount();
 }
 
 // Get Trace Status (clear Error flags)
 //   return: Trace Status (Active flag and Error flags)
-static uint8_t GetTraceStatus (void) {
+uint8_t GetTraceStatus (void)
+{
   uint8_t  status;
   uint32_t n;
 
@@ -410,11 +143,13 @@ static uint8_t GetTraceStatus (void) {
   return (status);
 }
 
+#if 0
 // Set Trace Error flag(s)
 //   flag:  error flag(s) to set
 static void SetTraceError (uint8_t flag) {
   TraceError[TraceError_n] |= flag;
 }
+#endif
 
 
 // Process SWO Transport command and prepare response
@@ -564,7 +299,8 @@ uint32_t SWO_Baudrate (const uint8_t *request, uint8_t *response) {
 //   response: pointer to response data
 //   return:   number of bytes in response (lower 16 bits)
 //             number of bytes in request (upper 16 bits)
-uint32_t SWO_Control (const uint8_t *request, uint8_t *response) {
+uint32_t SWO_Control (const uint8_t *request, uint8_t *response)
+{
   uint8_t  active;
   uint32_t result;
 
@@ -591,11 +327,6 @@ uint32_t SWO_Control (const uint8_t *request, uint8_t *response) {
     }
     if (result != 0U) {
       TraceStatus = active;
-#if (SWO_STREAM != 0)
-      if (TraceTransport == 2U) {
-        osThreadFlagsSet(SWO_ThreadId, 1U);
-      }
-#endif
     }
   } else {
     result = 1U;
@@ -667,10 +398,9 @@ uint32_t SWO_ExtendedStatus (const uint8_t *request, uint8_t *response) {
 #if (TIMESTAMP_CLOCK != 0U)
   if (cmd & 0x04U) {
     do {
-      TraceUpdate = 0U;
       index = TraceTimestamp.index;
       tick  = TraceTimestamp.tick;
-    } while (TraceUpdate != 0U);
+    } while (TraceBuffer_IsUpdated() != 0U);
     *response++ = (uint8_t)(index >>  0);
     *response++ = (uint8_t)(index >>  8);
     *response++ = (uint8_t)(index >> 16);
@@ -695,8 +425,7 @@ uint32_t SWO_ExtendedStatus (const uint8_t *request, uint8_t *response) {
 uint32_t SWO_Data (const uint8_t *request, uint8_t *response) {
   uint8_t  status;
   uint32_t count;
-  uint32_t index;
-  uint32_t n, i;
+  uint32_t n;
 
   status = GetTraceStatus();
   count  = GetTraceCount();
@@ -719,80 +448,20 @@ uint32_t SWO_Data (const uint8_t *request, uint8_t *response) {
   *response++ = (uint8_t)(count >> 8);
 
   if (TraceTransport == 1U) {
-    index = TraceIndexO;
-    for (i = index, n = count; n; n--) {
-      i &= SWO_BUFFER_SIZE - 1U;
-      *response++ = TraceBuf[i++];
-    }
-    TraceIndexO = index + count;
-    ResumeTrace();
+    TraceBuffer_Drain(response, count);
   }
 
   return ((2U << 16) | (3U + count));
 }
 
-
-#if (SWO_STREAM != 0)
-
-// SWO Data Transfer complete callback
-void SWO_TransferComplete (void) {
-  TraceIndexO += TransferSize;
-  TransferBusy = 0U;
-  ResumeTrace();
-  osThreadFlagsSet(SWO_ThreadId, 1U);
+uint32_t SWO_GetTraceMode(void)
+{
+  return TraceMode;
 }
 
-// SWO Thread
-__NO_RETURN void SWO_Thread (void *argument) {
-  uint32_t timeout;
-  uint32_t flags;
-  uint32_t count;
-  uint32_t index;
-  uint32_t i, n;
-  (void)   argument;
-
-  timeout = osWaitForever;
-
-  for (;;) {
-    flags = osThreadFlagsWait(1U, osFlagsWaitAny, timeout);
-    if (TraceStatus & DAP_SWO_CAPTURE_ACTIVE) {
-      timeout = SWO_STREAM_TIMEOUT;
-    } else {
-      timeout = osWaitForever;
-      flags   = osFlagsErrorTimeout;
-    }
-    if (TransferBusy == 0U) {
-      count = GetTraceCount();
-      if (count != 0U) {
-        index = TraceIndexO & (SWO_BUFFER_SIZE - 1U);
-        n = SWO_BUFFER_SIZE - index;
-        if (count > n) {
-          count = n;
-        }
-        if (flags != osFlagsErrorTimeout) {
-          i = index & (USB_BLOCK_SIZE - 1U);
-          if (i == 0U) {
-            count &= ~(USB_BLOCK_SIZE - 1U);
-          } else {
-            n = USB_BLOCK_SIZE - i;
-            if (count >= n) {
-              count = n;
-            } else {
-              count = 0U;
-            }
-          }
-        }
-        if (count != 0U) {
-          TransferSize = count;
-          TransferBusy = 1U;
-          SWO_QueueTransfer(&TraceBuf[index], count);
-        }
-      }
-    }
-  }
+uint32_t SWO_GetTransportMode(void)
+{
+  return TraceTransport;
 }
-
-#endif  /* (SWO_STREAM != 0) */
-
 
 #endif  /* ((SWO_UART != 0) || (SWO_MANCHESTER != 0)) */

--- a/src/cmsis_dap_device.c
+++ b/src/cmsis_dap_device.c
@@ -21,7 +21,6 @@
  * THE SOFTWARE. */
 
 #include "tusb_option.h"
-#include <stdint.h>
 
 #if (CFG_TUD_ENABLED && CFG_TUD_CMSIS_DAP)
 

--- a/src/cmsis_dap_device.h
+++ b/src/cmsis_dap_device.h
@@ -38,7 +38,11 @@ uint32_t tud_cmsis_dap_n_acquire_request_buffer(uint8_t itf, const uint8_t **pbu
 void     tud_cmsis_dap_n_release_request_buffer(uint8_t itf);
 uint32_t tud_cmsis_dap_n_acquire_response_buffer(uint8_t itf, uint8_t **pbuf);
 void     tud_cmsis_dap_n_release_response_buffer(uint8_t itf, uint32_t bufsize);
-bool     tud_cmsis_dap_n_swo_write(uint8_t itf, void const *data, uint16_t len);
+uint32_t tud_cmsis_dap_n_swo_enqueue(uint8_t itf, void const *data, uint32_t len);
+uint32_t tud_cmsis_dap_n_swo_dequeue(uint8_t itf, void* buffer, uint32_t bufsize);
+uint32_t tud_cmsis_dap_n_swo_free(uint8_t itf);
+uint32_t tud_cmsis_dap_n_swo_used(uint8_t itf);
+uint32_t tud_cmsis_dap_n_swo_clear(uint8_t itf);
 
 //--------------------------------------------------------------------+
 // Application API (Single Port)
@@ -48,7 +52,11 @@ static inline uint32_t tud_cmsis_dap_acquire_request_buffer(const uint8_t **pbuf
 static inline void     tud_cmsis_dap_release_request_buffer(void);
 static inline uint32_t tud_cmsis_dap_acquire_response_buffer(uint8_t **pbuf);
 static inline void     tud_cmsis_dap_release_response_buffer(uint32_t bufsize);
-static inline bool     tud_cmsis_dap_swo_write(void const *data, uint16_t len);
+static inline bool     tud_cmsis_dap_swo_enqueue(void const *data, uint16_t len);
+static inline uint32_t tud_cmsis_dap_swo_dequeue(void* buffer, uint32_t bufsize);
+static inline uint32_t tud_cmsis_dap_swo_free(void);
+static inline uint32_t tud_cmsis_dap_swo_used(void);
+static inline uint32_t tud_cmsis_dap_swo_clear(void);
 
 //--------------------------------------------------------------------+
 // Application Callback API (weak is optional)
@@ -56,6 +64,9 @@ static inline bool     tud_cmsis_dap_swo_write(void const *data, uint16_t len);
 
 // Invoked when abort request is received
 void tud_cmsis_dap_transfer_abort_cb(uint8_t itf);
+
+// Invoked when SWO control
+uint8_t tud_cmsis_dap_swo_control_cb(uint8_t intf, uint8_t control);
 
 // Invoked when SWO transfer finished
 void tud_cmsis_dap_swo_write_cb(uint8_t intf);
@@ -88,9 +99,28 @@ static inline void tud_cmsis_dap_release_response_buffer(uint32_t bufsize)
   tud_cmsis_dap_n_release_response_buffer(0, bufsize);
 }
 
-static inline bool tud_cmsis_dap_swo_write(void const *data, uint16_t len)
+static inline bool tud_cmsis_dap_swo_enqueue(void const *data, uint16_t len)
 {
-  return tud_cmsis_dap_n_swo_write(0, data, len);
+  return tud_cmsis_dap_n_swo_enqueue(0, data, len);
+}
+
+static inline uint32_t tud_cmsis_dap_swo_dequeue(void* buffer, uint32_t bufsize)
+{
+  return tud_cmsis_dap_n_swo_dequeue(0, buffer, bufsize);
+}
+
+static inline uint32_t tud_cmsis_dap_swo_free(void)
+{
+  return tud_cmsis_dap_n_swo_free(0);
+}
+
+static inline uint32_t tud_cmsis_dap_swo_used(void)
+{
+  return tud_cmsis_dap_n_swo_used(0);
+}
+static inline uint32_t tud_cmsis_dap_swo_clear(void)
+{
+  return tud_cmsis_dap_n_swo_clear(0);
 }
 
 //--------------------------------------------------------------------+

--- a/src/cmsis_dap_device.h
+++ b/src/cmsis_dap_device.h
@@ -65,11 +65,6 @@ static inline uint32_t tud_cmsis_dap_swo_clear(void);
 // Invoked when abort request is received
 void tud_cmsis_dap_transfer_abort_cb(uint8_t itf);
 
-// Invoked when SWO control
-uint8_t tud_cmsis_dap_swo_control_cb(uint8_t intf, uint8_t control);
-
-// Invoked when SWO transfer finished
-void tud_cmsis_dap_swo_write_cb(uint8_t intf);
 //--------------------------------------------------------------------+
 // Inline Functions
 //--------------------------------------------------------------------+

--- a/src/main.c
+++ b/src/main.c
@@ -212,6 +212,7 @@ void dap_task(void)
 uint32_t SWO_Mode_UART(uint32_t enable)
 {
   int ret = board_swo_set_enabled(enable);
+  return ret;
 }
 
 //   return:   actual baudrate or 0 when not configured

--- a/src/main.c
+++ b/src/main.c
@@ -38,7 +38,9 @@
 //#define DEBUG
 #define URL  "studio.keil.arm.com/auth/login/"
 
-bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t const * request);
+uint32_t SWO_GetTraceMode(void);
+uint8_t GetTraceStatus(void);
+bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage,  const tusb_control_request_t * request);
 
 const tusb_desc_webusb_url_t desc_url =
 {
@@ -114,7 +116,6 @@ void tud_resume_cb(void)
 //--------------------------------------------------------------------+
 // CMSIS DAP v2 use vendor class
 //--------------------------------------------------------------------+
-
 // Invoked when a control transfer occurred on an interface of this class
 // Driver response accordingly to the request and the transfer stage (setup/data/ack)
 // return false to stall control endpoint (e.g unsupported request)
@@ -153,6 +154,7 @@ bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_requ
 
 void tud_cmsis_dap_transfer_abort_cb(uint8_t itf)
 {
+  (void)itf;
   DAP_TransferAbort = 1;
 }
 
@@ -174,22 +176,80 @@ void dap_task(void)
   const uint8_t *p_req;
   uint8_t *p_rsp;
   unsigned sz_req = tud_cmsis_dap_acquire_request_buffer(&p_req);
-  if (!sz_req) return;
-  unsigned sz_rsp = tud_cmsis_dap_acquire_response_buffer(&p_rsp);
-  TU_ASSERT(sz_rsp,);
+  if (sz_req) {
+    unsigned sz_rsp = tud_cmsis_dap_acquire_response_buffer(&p_rsp);
+    TU_ASSERT(sz_rsp,);
 
-  uint32_t result = DAP_ExecuteCommand(p_req, p_rsp);
+    uint32_t result = DAP_ExecuteCommand(p_req, p_rsp);
 #ifdef DEBUG
-  cdc_printf("%x %x -> %lx %x\n", p_req[0], sz_req, result, p_rsp[1]);
+    cdc_printf("%x %x -> %lx %x\n", p_req[0], sz_req, result, p_rsp[1]);
 #endif
 
-  tud_cmsis_dap_release_request_buffer();
-  tud_cmsis_dap_release_response_buffer(result & 0xFFFFU);
+    tud_cmsis_dap_release_request_buffer();
+    tud_cmsis_dap_release_response_buffer(result & 0xFFFFU);
 
 #ifdef DEBUG
-  tud_cdc_write_flush();
+    tud_cdc_write_flush();
+#endif
+  }
+
+#if ((SWO_UART != 0) || (SWO_MANCHESTER != 0))
+  if (GetTraceStatus() & DAP_SWO_CAPTURE_ACTIVE) {
+    unsigned reminder = tud_cmsis_dap_swo_free();
+    if (reminder) {
+      unsigned len = 0;
+      uint8_t buf[64];
+      if (DAP_SWO_UART == SWO_GetTraceMode()) {
+        len = board_swo_read(buf, sizeof(buf));
+      }
+      if (len) tud_cmsis_dap_swo_enqueue(buf, len);
+    }
+  }
 #endif
 }
+
+#if (SWO_UART != 0)
+uint32_t SWO_Mode_UART(uint32_t enable)
+{
+  int ret = board_swo_set_enabled(enable);
+}
+
+//   return:   actual baudrate or 0 when not configured
+uint32_t SWO_Baudrate_UART(uint32_t baudrate)
+{
+  if (baudrate > SWO_UART_MAX_BAUDRATE) {
+    baudrate = SWO_UART_MAX_BAUDRATE;
+  }
+  return board_swo_set_baudrate(baudrate);
+}
+
+uint32_t SWO_Control_UART(uint32_t active)
+{
+  return 1;
+}
+#endif
+
+#if ((SWO_UART != 0) || (SWO_MANCHESTER != 0))
+uint32_t TraceBuffer_IsUpdated(void)
+{
+  return 0;
+}
+
+uint32_t TraceBuffer_GetCount(void)
+{
+  return tud_cmsis_dap_swo_used();
+}
+
+void TraceBuffer_Clear(void)
+{
+  tud_cmsis_dap_swo_clear();
+}
+
+void TraceBuffer_Drain(uint8_t *data, uint32_t num)
+{
+   tud_cmsis_dap_swo_dequeue(data, num);
+}
+#endif
 
 //--------------------------------------------------------------------+
 // USB CDC
@@ -239,6 +299,7 @@ void cdc_task(void)
 
 void tud_cdc_line_coding_cb(uint8_t itf, cdc_line_coding_t const* line_coding)
 {
+  (void)itf;
   board_uart_set_baudrate(line_coding->bit_rate);
 }
 

--- a/src/rp2040/DAP_config.h
+++ b/src/rp2040/DAP_config.h
@@ -90,7 +90,7 @@ This information includes:
 
 /// Indicate that UART Serial Wire Output (SWO) trace is available.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
-#define SWO_UART                0               ///< SWO UART:  1 = available, 0 = not available.
+#define SWO_UART                1               ///< SWO UART:  1 = available, 0 = not available.
 
 /// USART Driver instance number for the UART SWO.
 #define SWO_UART_DRIVER         0               ///< USART Driver instance number (Driver_USART#).
@@ -340,8 +340,8 @@ __STATIC_INLINE void PORT_SWD_SETUP (void) {
   gpio_set_function(PIN_SWDIO_TMS_BIT, GPIO_FUNC_SIO);
   gpio_set_function(PIN_nRESET_BIT, GPIO_FUNC_SIO);
 
-  gpio_set_pulls(PIN_SWCLK_TCK_BIT, false, true);
-  gpio_set_pulls(PIN_SWDIO_TMS_BIT, true, false);
+  gpio_pull_down(PIN_SWCLK_TCK_BIT);
+  gpio_pull_up(PIN_SWDIO_TMS_BIT);
   gpio_set_drive_strength(PIN_SWCLK_TCK_BIT, GPIO_DRIVE_STRENGTH_2MA);
   gpio_set_drive_strength(PIN_SWDIO_TMS_BIT, GPIO_DRIVE_STRENGTH_2MA);
 }
@@ -515,6 +515,7 @@ __STATIC_FORCEINLINE uint32_t PIN_nRESET_IN  (void) {
 */
 __STATIC_FORCEINLINE void     PIN_nRESET_OUT (uint32_t bit) {
   bool out = (bit & 1u) ? false: true;
+  gpio_clr_mask(1u << PIN_nRESET_BIT);
   gpio_set_dir(PIN_nRESET_BIT, out);
 }
 
@@ -600,7 +601,7 @@ __STATIC_INLINE void DAP_SETUP (void) {
   gpio_set_function(PIN_TDO_BIT, GPIO_FUNC_NULL);
   gpio_set_function(PIN_nRESET_BIT, GPIO_FUNC_NULL);
   gpio_set_function(PIN_RUNNING_LED_BIT, GPIO_FUNC_SIO);
-  gpio_set_pulls(PIN_nRESET_BIT, true, false);
+  gpio_pull_up(PIN_nRESET_BIT);
   gpio_set_dir_out_masked(1u << PIN_RUNNING_LED_BIT);
 }
 

--- a/src/rp2040/DAP_config.h
+++ b/src/rp2040/DAP_config.h
@@ -106,7 +106,7 @@ This information includes:
 #define SWO_BUFFER_SIZE         4096U           ///< SWO Trace Buffer Size in bytes (must be 2^n).
 
 /// SWO Streaming Trace.
-#define SWO_STREAM              0               ///< SWO Streaming Trace: 1 = available, 0 = not available.
+#define SWO_STREAM              1               ///< SWO Streaming Trace: 1 = available, 0 = not available.
 
 /// Clock frequency of the Test Domain Timer. Timer value is returned with \ref TIMESTAMP_GET.
 #define TIMESTAMP_CLOCK         100000000U      ///< Timestamp clock in Hz (0 = timestamps not supported).

--- a/src/rp2040/board.c
+++ b/src/rp2040/board.c
@@ -27,15 +27,25 @@
 #include "board.h"
 
 #define UART          uart1
-#define UART_TX_PIN   8
-#define UART_RX_PIN   9
+#define UART_TX_PIN   4
+#define UART_RX_PIN   5
+#define SWO           uart0
+#define SWO_RX_PIN    1
 
+static struct {
+  uint32_t baudrate;
+} g_swo = {
+  .baudrate = 115200,
+};
 
 void board_init(void)
 {
+  // UART
   gpio_set_function(UART_TX_PIN, GPIO_FUNC_UART);
   gpio_set_function(UART_RX_PIN, GPIO_FUNC_UART);
   uart_init(UART, 115200);
+  gpio_set_pulls(UART_TX_PIN, false, false);
+  gpio_pull_up(UART_RX_PIN);
 
   SystemCoreClockUpdate();
 }
@@ -43,34 +53,62 @@ void board_init(void)
 //--------------------------------------------------------------------+
 // Board porting API
 //--------------------------------------------------------------------+
-void board_uart_set_baudrate(unsigned bit_rate)
-{
-  uart_set_baudrate(UART, bit_rate);
-}
-
-int board_uart_read(uint8_t* buf, int len)
+static int _board_uart_read(uint8_t* buf, int len, uart_inst_t* uart)
 {
   int i;
-  for (i = 0; i < len; ++i) {
-    if (!uart_is_readable(UART))
-      break;
-    buf[i] = uart_getc(UART);
+  for (i = 0; i < len && uart_is_readable(uart); ++i) {
+    buf[i] = uart_getc(uart);
   }
   return i;
 }
 
-int board_uart_write(void const * buf, int len)
+static int _board_uart_write(void const * buf, int len, uart_inst_t* uart)
 {
   char const* p = (char const*)buf;
   int i;
   for (i = 0; i < len; ++i) {
-    uart_putc(UART, *p++);
+    uart_putc(uart, *p++);
   }
   return i;
 }
 
-//--------------------------------------------------------------------+
-// USB Interrupt Handler
-// rp2040 implementation will install approriate handler when initializing
-// tinyusb. There is no need to forward IRQ from application
-//--------------------------------------------------------------------+
+uint32_t board_uart_set_baudrate(unsigned bit_rate)
+{
+  return uart_set_baudrate(UART, bit_rate);
+}
+
+int board_uart_read(uint8_t* buf, int len)
+{
+  return _board_uart_read(buf, len, UART);
+}
+
+int board_uart_write(void const * buf, int len)
+{
+  return _board_uart_write(buf, len, UART);
+}
+
+int board_swo_set_enabled(int enabled)
+{
+  if (enabled) {
+    gpio_pull_up(SWO_RX_PIN);
+    gpio_set_function(SWO_RX_PIN, GPIO_FUNC_UART);
+    uint32_t baudrate = uart_init(SWO, g_swo.baudrate);
+    return (0 != baudrate) ? 1 : 0;
+  } else {
+    uart_deinit(SWO);
+    gpio_set_function(SWO_RX_PIN, GPIO_FUNC_NULL);
+    gpio_pull_down(SWO_RX_PIN);
+    return 1;
+  }
+}
+
+uint32_t board_swo_set_baudrate(unsigned bit_rate)
+{
+  g_swo.baudrate = bit_rate;
+  return uart_set_baudrate(SWO, bit_rate);
+}
+
+int board_swo_read(uint8_t* buf, int len)
+{
+  return _board_uart_read(buf, len, SWO);
+}

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -22,6 +22,7 @@
 
 #include "tusb.h"
 #include "usb_descriptors.h"
+#include "DAP_config.h"
 
 /* A combination of interfaces must have a unique product id, since PC will save device driver after the first plug.
  * Same VID/PID with different interface e.g MSC (first), then CDC (later) will possibly cause system error on PC.
@@ -78,7 +79,11 @@ enum
   ITF_NUM_TOTAL
 };
 
-#define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN + TUD_VENDOR_DESC_LEN)
+#if (SWO_STREAM!=0)
+# define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN + TUD_CMSIS_DAP_DESC_LEN)
+#else
+# define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN + TUD_VENDOR_DESC_LEN)
+#endif
 
 #if CFG_TUSB_MCU == OPT_MCU_LPC175X_6X || CFG_TUSB_MCU == OPT_MCU_LPC177X_8X || CFG_TUSB_MCU == OPT_MCU_LPC40XX
   // LPC 17xx and 40xx endpoint type (bulk/interrupt/iso) are fixed by its number
@@ -99,6 +104,7 @@ enum
   #define EPNUM_CDC_OUT    2
   #define EPNUM_VENDOR_IN  3
   #define EPNUM_VENDOR_OUT 3
+  #define EPNUM_VENDOR_IN2 4
 #endif
 
 uint8_t const desc_configuration[] =
@@ -109,8 +115,13 @@ uint8_t const desc_configuration[] =
   // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
   TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, 0x81, 8, EPNUM_CDC_OUT, 0x80 | EPNUM_CDC_IN, TUD_OPT_HIGH_SPEED ? 512 : 64),
 
+#if (SWO_STREAM!=0)
+  // Interface number, string index, EP Out & IN address, EP size
+  TUD_CMSIS_DAP_DESCRIPTOR(ITF_NUM_VENDOR, 5, EPNUM_VENDOR_OUT, 0x80 | EPNUM_VENDOR_IN, 0x80 | EPNUM_VENDOR_IN2, TUD_OPT_HIGH_SPEED ? 512 : 64),
+#else
   // Interface number, string index, EP Out & IN address, EP size
   TUD_VENDOR_DESCRIPTOR(ITF_NUM_VENDOR, 5, EPNUM_VENDOR_OUT, 0x80 | EPNUM_VENDOR_IN, TUD_OPT_HIGH_SPEED ? 512 : 64)
+#endif
 };
 
 // Invoked when received GET CONFIGURATION DESCRIPTOR

--- a/src/usb_descriptors.h
+++ b/src/usb_descriptors.h
@@ -31,4 +31,19 @@ enum
 
 extern uint8_t const desc_ms_os_20[];
 
+
+#define TUD_CMSIS_DAP_DESC_LEN  (9+7+7+7)
+
+// Interface number, string index, EP Out & IN address, EP size
+#define TUD_CMSIS_DAP_DESCRIPTOR(_itfnum, _stridx, _epout, _epin, _epswo, _epsize) \
+  /* Interface */\
+  9, TUSB_DESC_INTERFACE, _itfnum, 0, 3, TUSB_CLASS_VENDOR_SPECIFIC, 0x00, 0x00, _stridx,\
+  /* Endpoint Out */\
+  7, TUSB_DESC_ENDPOINT, _epout, TUSB_XFER_BULK, U16_TO_U8S_LE(_epsize), 0,\
+  /* Endpoint In */\
+  7, TUSB_DESC_ENDPOINT, _epin, TUSB_XFER_BULK, U16_TO_U8S_LE(_epsize), 0, \
+  /* Endpoint In (SWO_STREAM)*/\
+  7, TUSB_DESC_ENDPOINT, _epswo, TUSB_XFER_BULK, U16_TO_U8S_LE(_epsize), 0
+
+
 #endif /* USB_DESCRIPTORS_H_ */


### PR DESCRIPTION
Two transport modes are supported:
- DAP_SWO_Data command
- Separate bulk endpoint (SWO_STREAM)

Trace data is received via UART and stored in a FIFO, whose type is defined by TinyUSB.